### PR TITLE
Autohyphenate <p>

### DIFF
--- a/www/anime/index.html
+++ b/www/anime/index.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<html lang="no">
 <title>Sosialverkstedet</title>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">

--- a/www/css/style.css
+++ b/www/css/style.css
@@ -50,6 +50,7 @@ article {
 }
 article p {
 	text-align: justify;
+	hyphens: auto;
 }
 article:first-child {
 	border-radius: .5rem .5rem 0 0;

--- a/www/index.php
+++ b/www/index.php
@@ -1,4 +1,5 @@
 <?php require '../src/_autoload.php'; ?><!DOCTYPE html>
+<html lang="no">
 <title>Programvareverkstedet</title>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">

--- a/www/kurs/index.html
+++ b/www/kurs/index.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<html lang="no">
 <title>Kursverkstedet</title>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">

--- a/www/nerdepitsa/index.html
+++ b/www/nerdepitsa/index.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<html lang="no">
 <title>Sosialverkstedet</title>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">

--- a/www/prosjekt/index.html
+++ b/www/prosjekt/index.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<html lang="no">
 <title>Prosjektverkstedet</title>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">

--- a/www/soek/PR.html
+++ b/www/soek/PR.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<html lang="no">
 <title>Prosjektverkstedet</title>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">

--- a/www/soek/drift.html
+++ b/www/soek/drift.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<html lang="no">
 <title>Prosjektverkstedet</title>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">

--- a/www/soek/index.html
+++ b/www/soek/index.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html><!DOCTYPE html>
+<html lang="no">
 <title>Prosjektverkstedet</title>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">

--- a/www/soek/styret.html
+++ b/www/soek/styret.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<html lang="no">
 <title>Prosjektverkstedet</title>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">

--- a/www/soek/trikom.html
+++ b/www/soek/trikom.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<html lang="no">
 <title>Prosjektverkstedet</title>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">

--- a/www/sosiale/index.html
+++ b/www/sosiale/index.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<html lang="no">
 <title>Sosialverkstedet</title>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">


### PR DESCRIPTION
Add hyphens:auto to <p> to remove the ugly gaps introduced by
text-align: justified. This may cause some unwanted hyphenation on e.g.
email addresses. We should strive to not have long unbreakable words.
