### PR TITLE
Stop including BrettspillActivity

### DIFF
--- a/inc/include.php
+++ b/inc/include.php
@@ -28,7 +28,7 @@ $agenda = new \pvv\side\Agenda([
 		// new \pvv\side\social\NerdepitsaActivity,
 		// new \pvv\side\social\AnimekveldActivity,
 		new \pvv\side\social\HackekveldActivity,
-		new \pvv\side\social\BrettspillActivity,
+		// new \pvv\side\social\BrettspillActivity,
         	new \pvv\side\social\DriftkveldActivity,
 		new \pvv\side\DBActivity($pdo),
 	]);


### PR DESCRIPTION
This is nessecary until we have #40 

This change is temporary, as the board game event in april has been moved.
Undo this commit after April 23.